### PR TITLE
Include rule workspace in load paths

### DIFF
--- a/e2e/smoke/.bazelignore
+++ b/e2e/smoke/.bazelignore
@@ -1,0 +1,2 @@
+# separate module
+submodule/

--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -11,5 +11,6 @@ build_test(
         "//demo:demo",
         "//imports_css:imports_css",
         "//hello_world:hello_world",
+        "@submodule//nested",
     ],
 )

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,6 +1,6 @@
-bazel_dep(name = "gzgz_rules_sass", version = "1.0.0", dev_dependency = True)
-bazel_dep(name = "bazel_skylib", version = "1.3.0", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.3.0")
 
+bazel_dep(name = "gzgz_rules_sass", version = "1.0.0")
 local_path_override(
     module_name = "gzgz_rules_sass",
     path = "../..",
@@ -11,3 +11,9 @@ sass.toolchain(sass_version = "1.86.3")
 use_repo(sass, "sass_toolchains")
 
 register_toolchains("@sass_toolchains//:all")
+
+bazel_dep(name = "submodule")
+local_path_override(
+    module_name = "submodule",
+    path = "./submodule/",
+)

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,5 +1,4 @@
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
-
 bazel_dep(name = "gzgz_rules_sass", version = "1.0.0")
 local_path_override(
     module_name = "gzgz_rules_sass",

--- a/e2e/smoke/MODULE.bazel.lock
+++ b/e2e/smoke/MODULE.bazel.lock
@@ -87,8 +87,8 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/source.json": "f18d9ad3c4c54945bf422ad584fa6c5ca5b3116ff55a5b1bc77e5c1210be5960",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/source.json": "302b52a39259a85aa06ca3addb9787864ca3e03b432a5f964ea68244397e7544",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -138,7 +138,7 @@
     "@@gzgz_rules_sass+//sass:extensions.bzl%sass": {
       "general": {
         "bzlTransitiveDigest": "fNqVIutA6zvTy2KqYcU9uNLfEuQ0s2yFW/ciX+Ia8yo=",
-        "usagesDigest": "WxWaJswoDwvd+RMfsDqEz4VQi/GFHranIVzWMcIjHY4=",
+        "usagesDigest": "vtWL3XLvQ0cEanYgJOTBHaprjg74F2zUH7ZA3chbx0I=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -229,28 +229,6 @@
           }
         },
         "recordedRepoMappingEntries": []
-      }
-    },
-    "@@rules_java+//java:rules_java_deps.bzl%compatibility_proxy": {
-      "general": {
-        "bzlTransitiveDigest": "84xJEZ1jnXXwo8BXMprvBm++rRt4jsTu9liBxz0ivps=",
-        "usagesDigest": "jTQDdLDxsS43zuRmg1faAjIEPWdLAbDAowI1pInQSoo=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "compatibility_proxy": {
-            "repoRuleId": "@@rules_java+//java:rules_java_deps.bzl%_compatibility_proxy_repo_rule",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_java+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
       }
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -4,6 +4,12 @@ local_repository(
     path = "../..",
 )
 
+# Import the submodule.
+local_repository(
+    name = "submodule",
+    path = "./submodule/",
+)
+
 #---SNIP--- Below here is re-used in the workspace snippet published on releases
 
 ######################

--- a/e2e/smoke/submodule/BUILD
+++ b/e2e/smoke/submodule/BUILD
@@ -1,0 +1,1 @@
+# Submodule to test inclusion of external workspaces/modules.

--- a/e2e/smoke/submodule/MODULE.bazel
+++ b/e2e/smoke/submodule/MODULE.bazel
@@ -1,7 +1,6 @@
 module(name = "submodule")
 
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
-
 bazel_dep(name = "gzgz_rules_sass", version = "1.0.0")
 
 # Uncommenting this will result in the following error on Bazel 6.2.0:

--- a/e2e/smoke/submodule/MODULE.bazel
+++ b/e2e/smoke/submodule/MODULE.bazel
@@ -1,0 +1,21 @@
+module(name = "submodule")
+
+bazel_dep(name = "bazel_skylib", version = "1.3.0")
+
+bazel_dep(name = "gzgz_rules_sass", version = "1.0.0")
+
+# Uncommenting this will result in the following error on Bazel 6.2.0:
+# > ERROR: Error computing the main repository mapping: The MODULE.bazel file of submodule@_
+#          declares overrides
+# Using a local_path_override here would be more correct and would allow running the targets in
+# this module from inside of it. Bazel versions after 6.2.0 allow nested overrides correctly.
+# local_path_override(
+#     module_name = "gzgz_rules_sass",
+#     path = "../../..",
+# )
+
+sass = use_extension("@gzgz_rules_sass//sass:extensions.bzl", "sass")
+sass.toolchain(sass_version = "1.86.3")
+use_repo(sass, "sass_toolchains")
+
+register_toolchains("@sass_toolchains//:all")

--- a/e2e/smoke/submodule/WORKSPACE.bazel
+++ b/e2e/smoke/submodule/WORKSPACE.bazel
@@ -1,0 +1,14 @@
+# Override http_archive for local testing
+local_repository(
+    name = "gzgz_rules_sass",
+    path = "../../..",
+)
+
+load("@gzgz_rules_sass//sass:repositories.bzl", "gzgz_rules_sass_dependencies", "sass_register_toolchains")
+
+gzgz_rules_sass_dependencies()
+
+sass_register_toolchains(
+    name = "dart_sass",
+    sass_version = "1.86.3",  # Or any other version you like
+)

--- a/e2e/smoke/submodule/WORKSPACE.bzlmod
+++ b/e2e/smoke/submodule/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# When --enable_bzlmod is set, this file replaces WORKSPACE.bazel.
+# Dependencies then come from MODULE.bazel instead.

--- a/e2e/smoke/submodule/nested/BUILD
+++ b/e2e/smoke/submodule/nested/BUILD
@@ -1,0 +1,11 @@
+load("@gzgz_rules_sass//sass:defs.bzl", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+sass_binary(
+    name = "nested",
+    src = "dir/main.scss",
+    deps = [
+        "//shared:colors",
+    ],
+)

--- a/e2e/smoke/submodule/nested/dir/main.scss
+++ b/e2e/smoke/submodule/nested/dir/main.scss
@@ -1,0 +1,5 @@
+@use "shared/colors";
+
+body {
+  color: colors.$font-color;
+}

--- a/e2e/smoke/submodule/shared/BUILD
+++ b/e2e/smoke/submodule/shared/BUILD
@@ -1,0 +1,8 @@
+load("@gzgz_rules_sass//sass:defs.bzl", "sass_library")
+
+package(default_visibility = ["//visibility:public"])
+
+sass_library(
+    name = "colors",
+    srcs = ["_colors.scss"],
+)

--- a/e2e/smoke/submodule/shared/_colors.scss
+++ b/e2e/smoke/submodule/shared/_colors.scss
@@ -1,0 +1,1 @@
+$font-color: black;

--- a/sass/defs.bzl
+++ b/sass/defs.bzl
@@ -79,6 +79,11 @@ def _run_sass(ctx, input, css_output, map_output = None):
     # Sources for compilation may exist in the source tree, in bazel-bin, or bazel-genfiles.
     for prefix in [".", ctx.var["BINDIR"], ctx.var["GENDIR"]]:
         args.add("--load-path=%s/" % prefix)
+
+        # Include the workspace root if the rule is referenced in an external workspace. In this
+        # case, sources and outputs will be placed within the `external` folder.
+        if ctx.label.workspace_root != "":
+            args.add("--load-path=%s/%s" % (prefix, ctx.label.workspace_root))
         for include_path in ctx.attr.include_paths:
             args.add("--load-path=%s/%s" % (prefix, include_path))
 


### PR DESCRIPTION
I've found that if you have a sass_binary in an external workspace/module, then file references inside that workspace will not work correctly. This is because sources and outputs from the rule end up in a subfolder of `external` rather than the execroot, bindir or gendir directly.

This change loads the root of the workspace from the respective folders iff the rule is built in an external workspace.

I added a test to verify this fix works. Removing the changes to `defs.bzl` will fail the smoke test.